### PR TITLE
Support for non-ascii characters in source code.

### DIFF
--- a/lib/remap.js
+++ b/lib/remap.js
@@ -159,7 +159,7 @@ define([
 				}
 
 				if (match[1]) {
-					rawSourceMap = JSON.parse((new Buffer(match[2], 'base64').toString('ascii')));
+					rawSourceMap = JSON.parse((new Buffer(match[2], 'base64').toString('utf8')));
 				}
 				else {
 					var sourceMapPath = path.join(sourceMapDir, match[2]);


### PR DESCRIPTION
Non-ascii characters in sources break object parsing, if buffer converted with ascii encoding.