### PR TITLE
Fix path construction

### DIFF
--- a/lib/remap.js
+++ b/lib/remap.js
@@ -92,7 +92,7 @@ define([
 		}
 
 		return {
-			source: path.join(sourceMapDir, start.source),
+			source: path.relative(process.cwd(), path.resolve(sourceMapDir, start.source)),
 			loc: {
 				start: {
 					line: start.line,


### PR DESCRIPTION
**Problem:** I’m using OS X and has paths like this: `/Volumes/Sevilla/Users/kinday/Work/oboe-promise/Volumes/Sevilla/Users/kinday/Work/oboe-promise/index.js`. Notice the repeated part.

**Solution:** Using #resolve instead of #join prevents errors when source map has full path to file. It returns absolute path so we pass it to #relative.
