### PR TITLE
Support for coverage skip comments

### DIFF
--- a/lib/remap.js
+++ b/lib/remap.js
@@ -101,7 +101,8 @@ define([
 				end: {
 					line: end.line,
 					column: end.column
-				}
+				},
+				skip: location.skip
 			}
 		};
 	}
@@ -189,7 +190,8 @@ define([
 					var srcItem = {
 						name: genItem.name,
 						line: mapping.loc.start.line,
-						loc: mapping.loc
+						loc: mapping.loc,
+						skip: genItem.skip
 					};
 					var key = [
 						'f',


### PR DESCRIPTION
This adds support for `/* istanbul ignore next */`, `/* istanbul ignore if */` and `/* istanbul ignore else */` comments defined in https://github.com/gotwarlost/istanbul/blob/master/coverage.json.md

I don't know exactly how you would like tests to be added (if you agree with the feature), since I'm not completely sure on how your tests support files are generated (for example, you have skip comments in basic.js and not in basic.ts).