### PR TITLE
Add 'useAbsolutePaths' option

### DIFF
--- a/lib/remap.js
+++ b/lib/remap.js
@@ -59,11 +59,12 @@ define([
 	 * @param  {Object} location     The original location Object
 	 * @return {Object}              The remapped location Object
 	 */
-	function getMapping(sourceMap, sourceMapDir, location) {
+	function getMapping(sourceMap, sourceMapDir, location, useAbsolutePaths) {
 		/* jshint maxcomplexity: 11 */
 		var start = sourceMap.originalPositionFor(location.start);
 		var end = sourceMap.originalPositionFor(location.end);
 		var src;
+		var resolvedSource;
 
 		/* istanbul ignore if: edge case too hard to test for */
 		if (!start || !end) {
@@ -91,8 +92,12 @@ define([
 			end.column = end.column - 1;
 		}
 
+		resolvedSource = path.resolve(sourceMapDir, start.source);
+		if (!useAbsolutePaths) {
+			resolvedSource = path.relative(process.cwd(), resolvedSource);
+		}
 		return {
-			source: path.relative(process.cwd(), path.resolve(sourceMapDir, start.source)),
+			source: resolvedSource,
 			loc: {
 				start: {
 					line: start.line,
@@ -145,7 +150,9 @@ define([
 				};
 			}
 		}
-		
+
+		var useAbsolutePaths = !!options.useAbsolutePaths;
+
 		var sourceStore = options.sources;
 
 		var readJSON = options.readJSON || function readJSON(filePath) {
@@ -210,7 +217,7 @@ define([
 
 				Object.keys(fileCoverage.fnMap).forEach(function (index) {
 					var genItem = fileCoverage.fnMap[index];
-					var mapping = getMapping(sourceMap, sourceMapDir, genItem.loc);
+					var mapping = getMapping(sourceMap, sourceMapDir, genItem.loc, useAbsolutePaths);
 
 					if (!mapping) {
 						return;
@@ -246,7 +253,7 @@ define([
 
 				Object.keys(fileCoverage.statementMap).forEach(function (index) {
 					var genItem = fileCoverage.statementMap[index];
-					var mapping = getMapping(sourceMap, sourceMapDir, genItem);
+					var mapping = getMapping(sourceMap, sourceMapDir, genItem, useAbsolutePaths);
 
 					if (!mapping) {
 						return;
@@ -280,7 +287,7 @@ define([
 					var key = [ 'b' ];
 
 					for (var i = 0; i < genItem.locations.length; ++i) {
-						var mapping = getMapping(sourceMap, sourceMapDir, genItem.locations[i]);
+						var mapping = getMapping(sourceMap, sourceMapDir, genItem.locations[i], useAbsolutePaths);
 						if (!mapping) {
 							return;
 						}

--- a/tasks/remapIstanbul.js
+++ b/tasks/remapIstanbul.js
@@ -20,7 +20,8 @@ module.exports = function (grunt) {
 				readFile: grunt.readFile,
 				readJSON: grunt.readJSON,
 				warn: grunt.fail.warn,
-				sources: sources
+				sources: sources,
+				useAbsolutePaths: options.useAbsolutePaths
 			});
 
 			if (!Object.keys(sources.map).length) {

--- a/tests/unit/lib/remap.js
+++ b/tests/unit/lib/remap.js
@@ -1,11 +1,12 @@
 define([
 	'intern!object',
 	'intern/chai!assert',
+	'intern/dojo/node!path',
 	'../../../lib/node!istanbul/lib/collector',
 	'../../../lib/node!istanbul/lib/store/memory',
 	'../../../lib/loadCoverage',
 	'../../../lib/remap'
-], function (registerSuite, assert, Collector, MemoryStore, loadCoverage, remap) {
+], function (registerSuite, assert, path, Collector, MemoryStore, loadCoverage, remap) {
 	registerSuite({
 		name: 'remap-istanbul/lib/remap',
 
@@ -147,6 +148,18 @@ define([
 			
 			assert.strictEqual(1, warnStack.length);
 			assert.strictEqual(warnStack[0][0], 'Excluding: "tests/unit/support/foo.js"');
+		},
+
+		'useAbsolutePaths': function () {
+			var coverage = remap(loadCoverage('tests/unit/support/coverage.json'), {
+				useAbsolutePaths: true
+			});
+
+			var absoluteKey = path.resolve(process.cwd(), 'tests/unit/support/basic.ts');
+			assert(coverage.store.map[absoluteKey],
+				'The Collector should have a key with absolute path');
+			assert.strictEqual(Object.keys(coverage.store.map).length, 1,
+				'Collector should only have one map');
 		}
 	});
 });


### PR DESCRIPTION
'useAbsolutePaths' enforces using absolute paths in the output json file.
This is useful for combining coverage reports from different projects with istanbul-combine.