### PR TITLE
exclude files from the output

### DIFF
--- a/lib/remap.js
+++ b/lib/remap.js
@@ -330,6 +330,16 @@ define([
 		});
 
 		var collector = new Collector();
+		
+		srcCoverage = Object.keys(srcCoverage)
+			.filter(function(filePath){
+				return !(exclude && exclude(filePath))
+			})
+			.reduce(function(obj, name){
+				obj[name] = srcCoverage[name]
+				return obj
+			}, {})
+		
 		collector.add(srcCoverage);
 
 		/* refreshes the line counts for reports */


### PR DESCRIPTION
This re-uses the same exclude regex to remove files after mapping back.

There are obviously ways to improve performance here, but this at least works correctly.