### PR TITLE
Pass report options to the reporters.

### DIFF
--- a/bin/remap-istanbul
+++ b/bin/remap-istanbul
@@ -121,13 +121,14 @@ function main (argv) {
 		var collector = remap(coverage, basePath ? {
 			basePath: basePath
 		} : {});
+		var reportOptions = {};
 		/* istanbul ignore else: too hard to test writing to stdout */
 		if (output) {
-			return writeReport(collector, reportType || 'json', output);
+			return writeReport(collector, reportType || 'json', reportOptions, output);
 		}
 		else {
 			if (reportType && (reportType === 'lcovonly' || reportType === 'text-lcov')) {
-				return writeReport(collector, 'text-lcov');
+				return writeReport(collector, 'text-lcov', reportOptions);
 			}
 			else {
 				process.stdout.write(JSON.stringify(collector.getFinalCoverage()) + '\n');

--- a/lib/gulpRemapIstanbul.js
+++ b/lib/gulpRemapIstanbul.js
@@ -45,7 +45,7 @@ define([
 
 			if (opts.reports) {
 				for (var key in opts.reports) {
-					p.push(writeReport(collector, key, opts.reports[key], sources));
+					p.push(writeReport(collector, key, opts.reportOpts || {}, opts.reports[key], sources));
 				}
 			}
 

--- a/lib/writeReport.js
+++ b/lib/writeReport.js
@@ -27,6 +27,7 @@ define([
 	 *                                             collector
 	 * @param  {string}          reportType    The name of the report type to
 	 *                                         generate
+	 * @param  {object}			 reportOptions The options to pass to the reporter
 	 * @param  {string|function} dest          The filename or outputting
 	 *                                         function to use for generating
 	 *                                         the report
@@ -35,14 +36,14 @@ define([
 	 * @return {Promise}                       A promise that resolves when the
 	 *                                         report is complete.
 	 */
-	return function writeReport(collector, reportType, dest, sources) {
+	return function writeReport(collector, reportType, reportOptions, dest, sources) {
 		return new Promise(function (resolve, reject) {
 			if (!(reportType in istanbulReportTypes)) {
 				reject(new SyntaxError('Unrecognized report type of "' + reportType + '".'));
 				return;
 			}
-			require([ './node!istanbul/lib/report/' + reportType ], function (Reporter){
-				var options = {};
+			require([ './node!istanbul/lib/report/' + reportType, './node!extend' ], function (Reporter, extend){
+				var options = extend(true, {}, reportOptions);
 				switch (istanbulReportTypes[reportType]) {
 				case 'file':
 					options.file = dest;

--- a/main.js
+++ b/main.js
@@ -12,10 +12,10 @@ var MemoryStore = require('istanbul/lib/store/memory');
  *                                an array of strings.
  * @param  {Object} reports An object where each key is the report type required and the value
  *                          is the destination for the report.
- * @param  {Object} reportOpts? An object containing the report options.
+ * @param  {Object} reportOptions? An object containing the report options.
  * @return {Promise}         A promise that will resolve when all the reports are written.
  */
-module.exports = function (sources, reports, reportOpts) {
+module.exports = function (sources, reports, reportOptions) {
 	var sourceStore = new MemoryStore();
 	var collector = remap(loadCoverage(sources), {
 		sources: sourceStore
@@ -26,7 +26,7 @@ module.exports = function (sources, reports, reportOpts) {
 	} 
 
 	var p = Object.keys(reports).map(function (reportType) {
-		return writeReport(collector, reportType, reportOpts || {}, reports[reportType], sourceStore);
+		return writeReport(collector, reportType, reportOptions || {}, reports[reportType], sourceStore);
 	});
 	return Promise.all(p);
 };

--- a/main.js
+++ b/main.js
@@ -12,9 +12,10 @@ var MemoryStore = require('istanbul/lib/store/memory');
  *                                an array of strings.
  * @param  {Object} reports An object where each key is the report type required and the value
  *                          is the destination for the report.
+ * @param  {Object} reportOpts? An object containing the report options.
  * @return {Promise}         A promise that will resolve when all the reports are written.
  */
-module.exports = function (sources, reports) {
+module.exports = function (sources, reports, reportOpts) {
 	var sourceStore = new MemoryStore();
 	var collector = remap(loadCoverage(sources), {
 		sources: sourceStore
@@ -25,7 +26,7 @@ module.exports = function (sources, reports) {
 	} 
 
 	var p = Object.keys(reports).map(function (reportType) {
-		return writeReport(collector, reportType, reports[reportType], sourceStore);
+		return writeReport(collector, reportType, reportOpts || {}, reports[reportType], sourceStore);
 	});
 	return Promise.all(p);
 };

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 	},
 	"dependencies": {
 		"amdefine": "1.0.0",
+		"extend": "3.0.0",
 		"gulp-util": "3.0.7",
 		"istanbul": "0.4.1",
 		"source-map": "0.5.3",

--- a/tasks/remapIstanbul.js
+++ b/tasks/remapIstanbul.js
@@ -21,7 +21,7 @@ module.exports = function (grunt) {
 				grunt.log.error(message);
 			}
 		}
-		
+
 		this.files.forEach(function (file) {
 			var coverage = remap(loadCoverage(file.src, {
 				readJSON: grunt.readJSON,
@@ -38,11 +38,11 @@ module.exports = function (grunt) {
 			}
 
 			if (file.type && file.dest) {
-				p.push(writeReport(coverage, file.type, file.dest, sources));
+				p.push(writeReport(coverage, file.type, {}, file.dest, sources));
 			}
 			else {
 				p = p.concat(Object.keys(options.reports).map(function (key) {
-					return writeReport(coverage, key, options.reports[key], sources);
+					return writeReport(coverage, key, options.reportOpts || {}, options.reports[key], sources);
 				}));
 			}
 		});

--- a/tests/unit/lib/writeReport.js
+++ b/tests/unit/lib/writeReport.js
@@ -24,7 +24,7 @@ define([
 
 		'invalid': function () {
 			var dfd = this.async();
-			writeReport(coverage, 'foo', 'bar').then(dfd.reject, dfd.callback(function (error) {
+			writeReport(coverage, 'foo', {}, 'bar').then(dfd.reject, dfd.callback(function (error) {
 				assert.instanceOf(error, SyntaxError, 'should be rejected with SyntaxError');
 				assert.strictEqual(error.message, 'Unrecognized report type of "foo".',
 					'should have proper error message');
@@ -32,7 +32,7 @@ define([
 		},
 
 		'clover': function () {
-			return writeReport(coverage, 'clover', 'tmp/clover.xml').then(function () {
+			return writeReport(coverage, 'clover', {}, 'tmp/clover.xml').then(function () {
 				var contents = fs.readFileSync('tmp/clover.xml', { encoding: 'utf8' });
 				assert(contents, 'the report should exist');
 				assert.include(contents, 'path="tests/unit/support/basic.ts"', 'contains the remapped file');
@@ -40,7 +40,7 @@ define([
 		},
 
 		'cobertura': function () {
-			return writeReport(coverage, 'cobertura', 'tmp/cobertura.xml').then(function () {
+			return writeReport(coverage, 'cobertura', {}, 'tmp/cobertura.xml').then(function () {
 				var contents = fs.readFileSync('tmp/cobertura.xml', { encoding: 'utf8' });
 				assert(contents, 'the report should exist');
 				assert.include(contents, 'filename="tests/unit/support/basic.ts"', 'contains the remapped file');
@@ -48,7 +48,7 @@ define([
 		},
 
 		'html': function () {
-			return writeReport(coverage, 'html', 'tmp/html-report').then(function () {
+			return writeReport(coverage, 'html', {}, 'tmp/html-report').then(function () {
 				var html = fs.readFileSync('tmp/html-report/support/basic.ts.html', { encoding: 'utf8' });
 				assert(html, 'should have content for basic.ts');
 				assert.include(html, 'export class Foo {', 'should contain some of the origin file');
@@ -60,7 +60,7 @@ define([
 			var inlineSourceCoverage = remap(loadCoverage('tests/unit/support/coverage-inlinesource.json'), {
 				sources: sources
 			});
-			return writeReport(inlineSourceCoverage, 'html', 'tmp/html-report-inline', sources).then(function () {
+			return writeReport(inlineSourceCoverage, 'html', {}, 'tmp/html-report-inline', sources).then(function () {
 				var html = fs.readFileSync('tmp/html-report-inline/support/inlinesource.ts.html');
 				assert(html, 'should have content for inlinesource.ts');
 				assert.include(html, "let foo = new Foo", 'should contain some of the origin file');
@@ -68,7 +68,7 @@ define([
 		},
 
 		'json-summary': function () {
-			return writeReport(coverage, 'json-summary', 'tmp/summary.json').then(function () {
+			return writeReport(coverage, 'json-summary', {}, 'tmp/summary.json').then(function () {
 				var contents = fs.readFileSync('tmp/summary.json', { encoding: 'utf8' });
 				assert(contents, 'there should be contensts');
 				var summary = JSON.parse(contents);
@@ -79,7 +79,7 @@ define([
 		},
 
 		'json': function () {
-			return writeReport(coverage, 'json', 'tmp/coverage-out.json').then(function () {
+			return writeReport(coverage, 'json', {}, 'tmp/coverage-out.json').then(function () {
 				var contents = fs.readFileSync('tmp/coverage-out.json', { encoding: 'utf8' });
 				assert(contents, 'there should be contents');
 				var report = JSON.parse(contents);
@@ -89,7 +89,7 @@ define([
 		},
 
 		'lcovonly': function () {
-			return writeReport(coverage, 'lcovonly', 'tmp/lcov.info').then(function () {
+			return writeReport(coverage, 'lcovonly', {}, 'tmp/lcov.info').then(function () {
 				var contents = fs.readFileSync('tmp/lcov.info', { encoding: 'utf8' });
 				assert(contents, 'there should be contents');
 				assert.include(contents, 'SF:tests/unit/support/basic.ts',
@@ -98,7 +98,7 @@ define([
 		},
 
 		'teamcity': function () {
-			return writeReport(coverage, 'teamcity', 'tmp/teamcity.txt').then(function () {
+			return writeReport(coverage, 'teamcity', {}, 'tmp/teamcity.txt').then(function () {
 				var contents = fs.readFileSync('tmp/teamcity.txt', { encoding: 'utf8' });
 				assert(contents, 'there should be contents');
 				assert.include(contents, '##teamcity[blockOpened name=\'Code Coverage Summary\']',
@@ -110,7 +110,7 @@ define([
 			'no dest': function () {
 				consoleLog = console.log;
 				console.log = mockLog;
-				return writeReport(coverage, 'text-lcov').then(function () {
+				return writeReport(coverage, 'text-lcov', {}).then(function () {
 					console.log = consoleLog;
 					assert.strictEqual(consoleOutput.length, 59,
 						'console should have the right number of lines');
@@ -120,7 +120,7 @@ define([
 				});
 			},
 			'dest': function () {
-				return writeReport(coverage, 'text-lcov', function () {
+				return writeReport(coverage, 'text-lcov', {}, function () {
 					consoleOutput.push(arguments);
 				}).then(function () {
 					assert.strictEqual(consoleOutput.length, 59,
@@ -133,7 +133,7 @@ define([
 		},
 
 		'text-summary': function () {
-			return writeReport(coverage, 'text-summary', 'tmp/summary.txt').then(function () {
+			return writeReport(coverage, 'text-summary', {}, 'tmp/summary.txt').then(function () {
 				var contents = fs.readFileSync('tmp/summary.txt', { encoding: 'utf8' });
 				assert(contents, 'there should be contents');
 				assert.include(contents, 'Coverage summary', 'contains a summary header');
@@ -141,7 +141,7 @@ define([
 		},
 
 		'text': function () {
-			return writeReport(coverage, 'text', 'tmp/coverage.txt').then(function () {
+			return writeReport(coverage, 'text', {}, 'tmp/coverage.txt').then(function () {
 				var contents = fs.readFileSync('tmp/coverage.txt', { encoding: 'utf8' });
 				assert(contents, 'there should be contents');
 				assert.include(contents, 'basic.ts', 'contains the file we remapped');


### PR DESCRIPTION
This is a first step towards passing the report options to the reporters. I have taken some shortcuts by not looking into al the possible routes to the writeReport method. I’ve adjusted the tests, but have not written any tests for this particular feature. Also I only have tested it using the gulp plugin as that was our main reason for this change.

See #31.