### PR TITLE
Use basePath option to set the sourceMap sourceRoot property and resolve source accordingly

### DIFF
--- a/lib/remap.js
+++ b/lib/remap.js
@@ -92,7 +92,7 @@ define([
 		}
 
 		return {
-			source: path.relative(process.cwd(), path.resolve(sourceMapDir, start.source)),
+			source: path.relative(process.cwd(), start.source),
 			loc: {
 				start: {
 					line: start.line,
@@ -198,6 +198,7 @@ define([
 				}
 
 				sourceMapDir = options.basePath || sourceMapDir;
+				rawSourceMap.sourceRoot = sourceMapDir;
 
 				var sourceMap = new SourceMapConsumer(rawSourceMap);
 


### PR DESCRIPTION
This should fix #28

The sourceRoot property of the rawSourceMap was not set so /source/ was prepended to file paths by the SourceMapConsumer. I'm not sure how this could ever have worked. (I never got the example to work)

Setting the sourceRoot to the basePath provided by the user now correctly resolves the paths to the source files from the sourcemap.
