### PR TITLE
support sourcemap inside coverage code

### DIFF
--- a/lib/remap.js
+++ b/lib/remap.js
@@ -182,10 +182,16 @@ define([
 				var rawSourceMap;
 
 				if (!match) {
-					/* We couldn't find a source map, so will copy coverage after warning. */
-					warn(new Error('Could not find source map for: "' + filePath + '"'));
-					srcCoverage[filePath] = fileCoverage;
-					return;
+				    /* We couldn't find a source map inside the coverage code, try within the file itself */
+				    jsText = readFile(filePath);
+				    match = sourceMapRegEx.exec(jsText);
+			
+			            if (!match) {
+			                /* We couldn't find a source map, so will copy coverage after warning. */
+			                warn(new Error('Could not find source map for: "' + filePath + '"'));
+			                srcCoverage[filePath] = fileCoverage;
+			                return;
+			            }
 				}
 
 				if (match[1]) {

--- a/lib/remap.js
+++ b/lib/remap.js
@@ -176,7 +176,7 @@ define([
 					return;
 				}
 				var fileCoverage = item[filePath];
-				var jsText = readFile(filePath);
+				var jsText = fileCoverage.code;
 				var match = sourceMapRegEx.exec(jsText);
 				var sourceMapDir = path.dirname(filePath);
 				var rawSourceMap;


### PR DESCRIPTION
This PR will make it so it first looks for sourcemap within the code inside the coverage code itself, and only then try loading the original file itself.