### PR TITLE
Properly scope AMD define

### DIFF
--- a/lib/remap.js
+++ b/lib/remap.js
@@ -1,6 +1,6 @@
 /* jshint node: true */
 /*jshint -W079 */
-if (typeof define !== 'function') { /* istanbul ignore next */ var define = require('amdefine')(module); }
+(function(define) {
 define([
 	'require',
 	'exports',
@@ -338,3 +338,4 @@ define([
 		return collector;
 	};
 });
+})(typeof define === 'function' ? define : require('amdefine')(module));


### PR DESCRIPTION
The current define detection is invalid because by declaring `var define`, the top-level `define` in scope will always be undefined.

This adjustment should align the original intention I believe, but let me know if I'm missing anything here.