### PR TITLE
Respect Skip Flag in remap() - Fixes #57

### DIFF
--- a/bin/remap-istanbul
+++ b/bin/remap-istanbul
@@ -6,7 +6,6 @@ var loadCoverage = require('../lib/loadCoverage');
 var remap = require('../lib/remap');
 var writeReport = require('../lib/writeReport');
 var MemoryStore = require('istanbul/lib/store/memory');
-var Collector = require('istanbul/lib/collector');
 
 /**
  * Helper function that reads from standard in and resolves a Promise with the
@@ -119,9 +118,6 @@ function main (argv) {
 			/* istanbul ignore next */ readStdIn().then(function (data) {
 				try {
 					data = JSON.parse(data);
-					var collector = new Collector();
-					collector.add(data);
-					return collector.getFinalCoverage();
 				}
 				catch (err) {
 					console.error(err.stack);

--- a/lib/remap.js
+++ b/lib/remap.js
@@ -261,6 +261,9 @@ define([
 
 				Object.keys(fileCoverage.statementMap).forEach(function (index) {
 					var genItem = fileCoverage.statementMap[index];
+					if (genItem.skip) {
+						return;
+					}
 					var mapping = getMapping(sourceMap, sourceMapDir, genItem, useAbsolutePaths, inlineSourceMap);
 
 					if (!mapping) {


### PR DESCRIPTION
Many lines of code in complex babel transforms have no direct source-map equivalent, and will yield a line/start position of zero (such as transforms that inject fixed content before or after the file). This would manifest in the issue identified at:

https://github.com/SitePen/remap-istanbul/issues/57

This fix is to respect the skip flag on the genItem before performing the sourceMap lookup, which will throw an exception such as:

    TypeError: Line must be greater than or equal to 1, got 0