### PR TITLE
Graceful handling of invalid/non-existent sourceMappingURL

### DIFF
--- a/lib/remap.js
+++ b/lib/remap.js
@@ -169,7 +169,8 @@ define([
 
 		var readJSON = options.readJSON || function readJSON(filePath) {
 			if (!fs.existsSync(filePath)) {
-				throw new Error('Could not find file: "' + filePath + '"');
+				warn(new Error('Could not find file: "' + filePath + '"'));
+				return null;
 			}
 			return JSON.parse(fs.readFileSync(filePath));
 		};
@@ -208,20 +209,22 @@ define([
 				var sourceMapDir = path.dirname(filePath);
 				var rawSourceMap;
 
-				if (!match) {
+				if (match) {
+					if (match[1]) {
+						rawSourceMap = JSON.parse((new Buffer(match[2], 'base64').toString('utf8')));
+					}
+					else {
+						var sourceMapPath = path.join(sourceMapDir, match[2]);
+						rawSourceMap = readJSON(sourceMapPath);
+						sourceMapDir = path.dirname(sourceMapPath);
+					}
+				}
+
+				if (!match || !rawSourceMap) {
 					/* We couldn't find a source map, so will copy coverage after warning. */
 					warn(new Error('Could not find source map for: "' + filePath + '"'));
 					srcCoverage[filePath] = fileCoverage;
 					return;
-				}
-
-				if (match[1]) {
-					rawSourceMap = JSON.parse((new Buffer(match[2], 'base64').toString('utf8')));
-				}
-				else {
-					var sourceMapPath = path.join(sourceMapDir, match[2]);
-					rawSourceMap = readJSON(sourceMapPath);
-					sourceMapDir = path.dirname(sourceMapPath);
 				}
 
 				sourceMapDir = options.basePath || sourceMapDir;

--- a/tests/unit/lib/remap.js
+++ b/tests/unit/lib/remap.js
@@ -90,17 +90,28 @@ define([
 			assert.strictEqual(warnStack.length, 2, 'warn should have been called twice');
 			assert.instanceOf(warnStack[0][0], Error, 'should have been called with error');
 			assert.strictEqual(warnStack[0][0].message, 'Could not find file: "tests/unit/support/bad.js"',
-				'proper error message should have been returend');
+				'proper error message should have been returned');
 			assert.instanceOf(warnStack[1][0], Error, 'should have been called with error');
 			assert.strictEqual(warnStack[1][0].message, 'Could not find source map for: "tests/unit/support/bad.js"',
-				'proper error message should have been returend');
+				'proper error message should have been returned');
 		},
 
 		'missing source map': function () {
-			var coverage = loadCoverage('tests/unit/support/missingmapcoverage.json');
-			assert.throws(function () {
-				remap(coverage);
-			}, Error);
+			var warnStack = [];
+			function warn() {
+				warnStack.push(arguments);
+			}
+			remap(loadCoverage('tests/unit/support/missingmapcoverage.json'), {
+				warn: warn
+			});
+
+			assert.strictEqual(warnStack.length, 2, 'warn should have been called twice');
+			assert.instanceOf(warnStack[0][0], Error, 'should have been called with error');
+			assert.strictEqual(warnStack[0][0].message, 'Could not find file: "tests/unit/support/missingmap.js.map"',
+				'proper error message should have been returned');
+			assert.instanceOf(warnStack[1][0], Error, 'should have been called with error');
+			assert.strictEqual(warnStack[1][0].message, 'Could not find source map for: "tests/unit/support/missingmap.js"',
+				'proper error message should have been returned');
 		},
 
 		'unicode in map': function () {


### PR DESCRIPTION
Currently, `remap-istanbul` gracefully handles non-existent inlined sourcemaps, but throws fatal error for non-existent external sourcemap files. This pr fixes that. Issue depicted [here](https://github.com/CanopyTax/node-jspm-jasmine/pull/27#issuecomment-220664578).