### PR TITLE
stop using WeakMap when not available

### DIFF
--- a/lib/remap.js
+++ b/lib/remap.js
@@ -15,8 +15,29 @@ define([
 
 	var sourceMapRegEx = /(?:\/{2}[#@]{1,2}|\/\*)\s+sourceMappingURL\s*=\s*(data:(?:[^;]+;)+base64,)?(\S+)/;
 
-	var metaInfo = new WeakMap();
+	var MaybeWeakMap = typeof WeakMap === 'function' ? WeakMap : function(){
+		var objectList = [];
+		var dataList = [];
 
+		this.set = function(object, data) {
+			var index = objectList.indexOf(object);
+			if(index !== -1) {
+				data[index] = data;
+			} else {
+				objectList.push(object);
+				dataList.push(data);
+			}
+		};
+
+		this.get = function(object) {
+			var index = objectList.indexOf(object);
+			if(index !== -1) {
+				return dataList[index];
+			}
+		};
+	};
+
+	var metaInfo = new MaybeWeakMap();
 	/**
 	 * Generate a coverage object that will be filled with the remapped data
 	 * @param  {Object} srcCoverage The coverage object to be populated


### PR DESCRIPTION
If the node version is below 0.12, the WeakMap implementation is not available. This patch enebles remap to run in older node environments.