### PR TITLE
fix(remap) Added source code as an array to fileCoverage object.

### DIFF
--- a/lib/remap.js
+++ b/lib/remap.js
@@ -211,6 +211,11 @@ define([
 				if (!match) {
 					/* We couldn't find a source map, so will copy coverage after warning. */
 					warn(new Error('Could not find source map for: "' + filePath + '"'));
+					try {
+          					fileCoverage.code = String(fs.readFileSync(filePath)).split('\n');
+					} catch(e) {
+						warn(new Error('Could find source for : "' + filePath + '"'));
+					}
 					srcCoverage[filePath] = fileCoverage;
 					return;
 				}

--- a/tests/unit/lib/remap.js
+++ b/tests/unit/lib/remap.js
@@ -87,7 +87,7 @@ define([
 			remap(loadCoverage('tests/unit/support/badcoverage.json'), {
 				warn: warn
 			});
-			assert.strictEqual(warnStack.length, 2, 'warn should have been called twice');
+			assert.strictEqual(warnStack.length, 3, 'warn should have been called three times');
 			assert.instanceOf(warnStack[0][0], Error, 'should have been called with error');
 			assert.strictEqual(warnStack[0][0].message, 'Could not find file: "tests/unit/support/bad.js"',
 				'proper error message should have been returend');


### PR DESCRIPTION
Added source code as an array to fileCoverage object so that istanbul html reporter doesn't throw error
Error: Unable to find entry for [x]