### PR TITLE
Fixed issue where basePath option was ignored in case of inline sourc…

### DIFF
--- a/lib/remap.js
+++ b/lib/remap.js
@@ -383,7 +383,7 @@ define([
 						}
 						return absolutePath;
 					};
-					var fullSourceMapPath = getPath(srcCoverage[fileName].path);
+					var fullSourceMapPath = getPath(origFileName.replace(path.extname(origFileName), path.extname(origSourceFilename)));
 					srcCoverage[fullSourceMapPath] = srcCoverage[fileName];
 					srcCoverage[fullSourceMapPath].path = fullSourceMapPath;
 					delete srcCoverage[fileName];

--- a/lib/remap.js
+++ b/lib/remap.js
@@ -373,6 +373,21 @@ define([
 						data.b[brIndex][i] += hits[i];
 					}
 				});
+
+				if (sourceMap.sourcesContent && options.basePath) {
+					// Convert path to use base path option
+					var getPath = function (filePath) {
+						var absolutePath = path.resolve(options.basePath, filePath);
+						if (!useAbsolutePaths) {
+							return path.relative(process.cwd(), absolutePath);
+						}
+						return absolutePath;
+					};
+					var fullSourceMapPath = getPath(srcCoverage[fileName].path);
+					srcCoverage[fullSourceMapPath] = srcCoverage[fileName];
+					srcCoverage[fullSourceMapPath].path = fullSourceMapPath;
+					delete srcCoverage[fileName];
+				}
 			});
 		});
 

--- a/tests/unit/lib/remap.js
+++ b/tests/unit/lib/remap.js
@@ -46,6 +46,14 @@ define([
 			assert(store.map['tests/unit/support/inlinesource.ts'], 'Source should have been retrieved from source map');
 		},
 
+		'base64 source map with base path': function () {
+			var basePath = 'foo/bar';
+			var coverage = remap(loadCoverage('tests/unit/support/coverage-inlinesource.json'), {
+				basePath: basePath
+			});
+			assert(coverage.store.map[basePath + '/tests/unit/support/inlinesource.ts'], 'Source should have been retrieved from source map using base path');
+		},
+
 		'coverage includes code': function () {
 			var coverage = remap(loadCoverage('tests/unit/support/coverage-code.json'));
 			assert.instanceOf(coverage, Collector, 'Return values should be instance of Collector');

--- a/tests/unit/lib/remap.js
+++ b/tests/unit/lib/remap.js
@@ -51,7 +51,7 @@ define([
 			var coverage = remap(loadCoverage('tests/unit/support/coverage-inlinesource.json'), {
 				basePath: basePath
 			});
-			assert(coverage.store.map[basePath + '/tests/unit/support/inlinesource.ts'], 'Source should have been retrieved from source map using base path');
+			assert(coverage.store.map[basePath + '/inlinesource.ts'], 'Source should have been retrieved from source map using base path');
 		},
 
 		'coverage includes code': function () {


### PR DESCRIPTION
When using inline source maps the basePath option was not being used.
Added a unit test for validating this specific case.

 