### PR TITLE
Added path.normalize calls in tests.

### DIFF
--- a/tests/unit/lib/remap.js
+++ b/tests/unit/lib/remap.js
@@ -4,21 +4,22 @@ define([
 	'intern/dojo/node!path',
 	'../../../lib/node!istanbul/lib/collector',
 	'../../../lib/node!istanbul/lib/store/memory',
+	'../../../lib/node!path',
 	'../../../lib/loadCoverage',
 	'../../../lib/remap'
-], function (registerSuite, assert, path, Collector, MemoryStore, loadCoverage, remap) {
+], function (registerSuite, assert, path, Collector, MemoryStore, path, loadCoverage, remap) {
 	registerSuite({
 		name: 'remap-istanbul/lib/remap',
 
 		'remapping': function () {
 			var coverage = remap(loadCoverage('tests/unit/support/coverage.json'));
 			assert.instanceOf(coverage, Collector, 'Return values should be instance of Collector');
-			assert(coverage.store.map['tests/unit/support/basic.ts'],
+			assert(coverage.store.map[path.normalize('tests/unit/support/basic.ts')],
 				'The Collector should have a remapped key');
 			assert.strictEqual(Object.keys(coverage.store.map).length, 1,
 				'Collector should only have one map');
-			var map = JSON.parse(coverage.store.map['tests/unit/support/basic.ts']);
-			assert.strictEqual(map.path, 'tests/unit/support/basic.ts');
+			var map = JSON.parse(coverage.store.map[path.normalize('tests/unit/support/basic.ts')]);
+			assert.strictEqual(map.path, path.normalize('tests/unit/support/basic.ts'));
 			assert.strictEqual(Object.keys(map.statementMap).length, 28, 'Map should have 28 statements');
 			assert.strictEqual(Object.keys(map.fnMap).length, 6, 'Map should have 6 functions');
 			assert.strictEqual(Object.keys(map.branchMap).length, 6, 'Map should have 6 branches');
@@ -27,12 +28,12 @@ define([
 		'base64 source map': function () {
 			var coverage = remap(loadCoverage('tests/unit/support/inline-coverage.json'));
 			assert.instanceOf(coverage, Collector, 'Return values should be instance of Collector');
-			assert(coverage.store.map['tests/unit/support/basic.ts'],
+			assert(coverage.store.map[path.normalize('tests/unit/support/basic.ts')],
 				'The Collector should have a remapped key');
 			assert.strictEqual(Object.keys(coverage.store.map).length, 1,
 				'Collector should only have one map');
-			var map = JSON.parse(coverage.store.map['tests/unit/support/basic.ts']);
-			assert.strictEqual(map.path, 'tests/unit/support/basic.ts');
+			var map = JSON.parse(coverage.store.map[path.normalize('tests/unit/support/basic.ts')]);
+			assert.strictEqual(map.path, path.normalize('tests/unit/support/basic.ts'));
 			assert.strictEqual(Object.keys(map.statementMap).length, 28, 'Map should have 28 statements');
 			assert.strictEqual(Object.keys(map.fnMap).length, 6, 'Map should have 6 functions');
 			assert.strictEqual(Object.keys(map.branchMap).length, 6, 'Map should have 6 branches');
@@ -71,11 +72,11 @@ define([
 				basePath : 'foo/bar'
 			});
 
-			assert(coverage.store.map['foo/bar/basic.ts'],  'The base path provided should have been used');
+			assert(coverage.store.map[path.normalize('foo/bar/basic.ts')],  'The base path provided should have been used');
 			assert.strictEqual(Object.keys(coverage.store.map).length, 1,
 				'Collector should only have one map');
-			var map = JSON.parse(coverage.store.map['foo/bar/basic.ts']);
-			assert.strictEqual(map.path, 'foo/bar/basic.ts', 'The base path should be used in the map as well');
+			var map = JSON.parse(coverage.store.map[path.normalize('foo/bar/basic.ts')]);
+			assert.strictEqual(map.path, path.normalize('foo/bar/basic.ts'), 'The base path should be used in the map as well');
 		},
 
 		'missing coverage source': function () {
@@ -105,7 +106,7 @@ define([
 		'unicode in map': function () {
 			var coverage = remap(loadCoverage('tests/unit/support/coverage-unicode.json'));
 
-			assert(coverage.store.map['tests/unit/support/unicode.ts'], 'The file should have been properly mapped.');
+			assert(coverage.store.map[path.normalize('tests/unit/support/unicode.ts')], 'The file should have been properly mapped.');
 			assert.strictEqual(Object.keys(coverage.store.map).length, 1,
 				'Collector should have only one map.');
 		},
@@ -113,7 +114,7 @@ define([
 		'skip in source map': function () {
 			var coverage = remap(loadCoverage('tests/unit/support/coverage-skip.json'));
 
-			var coverageData = JSON.parse(coverage.store.map['tests/unit/support/basic.ts']);
+			var coverageData = JSON.parse(coverage.store.map[path.normalize('tests/unit/support/basic.ts')]);
 			assert.isTrue(coverageData.statementMap['18'].skip, 'skip is perpetuated');
 			assert.isUndefined(coverageData.statementMap['1'].skip, 'skip is not present');
 			assert.isTrue(coverageData.fnMap['5'].skip, 'skip is perpetuated');

--- a/tests/unit/lib/writeReport.js
+++ b/tests/unit/lib/writeReport.js
@@ -3,10 +3,11 @@ define([
 	'intern/chai!assert',
 	'../../../lib/node!fs',
 	'../../../lib/node!istanbul/lib/store/memory',
+	'../../../lib/node!path',
 	'../../../lib/loadCoverage',
 	'../../../lib/remap',
 	'../../../lib/writeReport'
-], function (registerSuite, assert, fs, MemoryStore, loadCoverage, remap, writeReport) {
+], function (registerSuite, assert, fs, MemoryStore, path, loadCoverage, remap, writeReport) {
 	var coverage;
 	var consoleLog;
 	var consoleOutput = [];
@@ -35,7 +36,7 @@ define([
 			return writeReport(coverage, 'clover', {}, 'tmp/clover.xml').then(function () {
 				var contents = fs.readFileSync('tmp/clover.xml', { encoding: 'utf8' });
 				assert(contents, 'the report should exist');
-				assert.include(contents, 'path="tests/unit/support/basic.ts"', 'contains the remapped file');
+				assert.include(contents, 'path="' + path.normalize('tests/unit/support/basic.ts') + '"', 'contains the remapped file');
 			});
 		},
 
@@ -43,7 +44,7 @@ define([
 			return writeReport(coverage, 'cobertura', {}, 'tmp/cobertura.xml').then(function () {
 				var contents = fs.readFileSync('tmp/cobertura.xml', { encoding: 'utf8' });
 				assert(contents, 'the report should exist');
-				assert.include(contents, 'filename="tests/unit/support/basic.ts"', 'contains the remapped file');
+				assert.include(contents, 'filename="' + path.normalize('tests/unit/support/basic.ts') + '"', 'contains the remapped file');
 			});
 		},
 
@@ -72,7 +73,7 @@ define([
 				var contents = fs.readFileSync('tmp/summary.json', { encoding: 'utf8' });
 				assert(contents, 'there should be contensts');
 				var summary = JSON.parse(contents);
-				assert(summary['tests/unit/support/basic.ts'], 'there should be a key with a summary');
+				assert(summary[path.normalize('tests/unit/support/basic.ts')], 'there should be a key with a summary');
 				assert(summary.total, 'there should be a total key');
 				assert.strictEqual(Object.keys(summary).length, 2, 'there should be only two keys');
 			});
@@ -83,7 +84,7 @@ define([
 				var contents = fs.readFileSync('tmp/coverage-out.json', { encoding: 'utf8' });
 				assert(contents, 'there should be contents');
 				var report = JSON.parse(contents);
-				assert(report['tests/unit/support/basic.ts'], 'there should be a key with coverage');
+				assert(report[path.normalize('tests/unit/support/basic.ts')], 'there should be a key with coverage');
 				assert.strictEqual(Object.keys(report).length, 1, 'there should be only one key in report');
 			});
 		},
@@ -92,7 +93,7 @@ define([
 			return writeReport(coverage, 'lcovonly', {}, 'tmp/lcov.info').then(function () {
 				var contents = fs.readFileSync('tmp/lcov.info', { encoding: 'utf8' });
 				assert(contents, 'there should be contents');
-				assert.include(contents, 'SF:tests/unit/support/basic.ts',
+				assert.include(contents, 'SF:' + path.normalize('tests/unit/support/basic.ts'),
 					'should contain the name of the remapped file');
 			});
 		},
@@ -114,7 +115,7 @@ define([
 					console.log = consoleLog;
 					assert.strictEqual(consoleOutput.length, 59,
 						'console should have the right number of lines');
-					assert.strictEqual(consoleOutput[1][0], 'SF:tests/unit/support/basic.ts',
+					assert.strictEqual(consoleOutput[1][0], 'SF:' + path.normalize('tests/unit/support/basic.ts'),
 						'console should have logged the right file');
 					consoleOutput = [];
 				});
@@ -125,7 +126,7 @@ define([
 				}).then(function () {
 					assert.strictEqual(consoleOutput.length, 59,
 						'console should have the right number of lines');
-					assert.strictEqual(consoleOutput[1][0], 'SF:tests/unit/support/basic.ts',
+					assert.strictEqual(consoleOutput[1][0], 'SF:' + path.normalize('tests/unit/support/basic.ts'),
 						'console should have logged the right file');
 					consoleOutput = [];
 				});

--- a/tests/unit/main.js
+++ b/tests/unit/main.js
@@ -2,8 +2,9 @@ define([
 	'intern!object',
 	'intern/chai!assert',
 	'../../../lib/node!fs',
+	'../../../lib/node!path',
 	'../../../lib/node!../../../main'
-], function (registerSuite, assert, fs, main) {
+], function (registerSuite, assert, fs, path, main) {
 	registerSuite({
 		name: 'main',
 
@@ -14,11 +15,11 @@ define([
 			}).then(function () {
 				var lcovonly = fs.readFileSync('tmp/main.lcov.info', { encoding: 'utf8' });
 				assert(lcovonly, 'should have returned content');
-				assert.include(lcovonly, 'SF:tests/unit/support/basic.ts',
+				assert.include(lcovonly, 'SF:'+path.normalize('tests/unit/support/basic.ts'),
 					'should have the mapped file name');
 				var json = JSON.parse(fs.readFileSync('tmp/main.json', { encoding: 'utf8' }));
 				assert(json, 'should have returned content');
-				assert(json['tests/unit/support/basic.ts'],
+				assert(json[path.normalize('tests/unit/support/basic.ts')],
 					'should have key named after mapped file');
 			});
 		},
@@ -29,7 +30,7 @@ define([
 			}).then(function () {
 				var json = JSON.parse(fs.readFileSync('tmp/main-string.json', { encoding: 'utf8' }));
 				assert(json, 'should have returned content');
-				assert(json['tests/unit/support/basic.ts'],
+				assert(json[path.normalize('tests/unit/support/basic.ts')],
 					'should have key named after mapped file');
 			});
 		},


### PR DESCRIPTION
In order to get the tests running on Windows, I went through and made sure paths entered as test information were normalized to OS. Source maps generated on Windows will use Windows path separators ('\'), so the paths used to check them should have them also.

I tried setting up a CLA, but couldn't log in. I hereby relinquish all claim and rights to this contribution into the public domain.