### PR TITLE
fixed: "path.extname" error in remap.js

### DIFF
--- a/lib/remap.js
+++ b/lib/remap.js
@@ -285,7 +285,7 @@ define([
 				if (sourceMap.sourcesContent) {
 					origSourceFilename = rawSourceMap.sources[0];
 
-					if(path.extname(origSourceFilename) !== ''){
+					if (origSourceFilename && path.extname(origSourceFilename) !== '') {
 						origFileName = rawSourceMap.file;
 						fileName = filePath.replace(path.extname(origFileName), path.extname(origSourceFilename));
 						rawSourceMap.file = fileName;


### PR DESCRIPTION
This fixes an issue where `undefined` is being passed to `path.extname` and then having `path` error.

I produced the above sceneraio by having a typescript file export only an interface. When the file was compiled by typescript it no longer had any content and I belive that caused the aforementioned error. Placing a single comment or var statement in the file stopped this error from occuring.

The stacktrace I received is included below.

```
 TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.extname (path.js:887:5)
    at $PWD/node_modules/remap-istanbul/lib/remap.js:291:37
    at Array.forEach (native)
    at $PWD/node_modules/remap-istanbul/lib/remap.js:214:22
    at Array.forEach (native)
    at remap ($PWD/node_modules/remap-istanbul/lib/remap.js:213:12)
    at DestroyableTransform._transform ($PWD/node_modules/remap-istanbul/lib/gulpRemapIstanbul.js:41:20)
    at DestroyableTransform.Transform._read ($PWD/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:159:10)
    at DestroyableTransform.Transform._write ($PWD/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:147:83)
    at doWrite ($PWD/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:313:64)
    at writeOrBuffer ($PWD/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:302:5)
    at DestroyableTransform.Writable.write ($PWD/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:241:11)
    at DestroyableTransform.ondata ($PWD/node_modules/through2/node_modules/readable-stream/lib/_stream_readable.js:531:20)
    at emitOne (events.js:96:13)
    at DestroyableTransform.emit (events.js:188:7)
```
