### PR TITLE
Fix: use sourcesContent in source map if available

### DIFF
--- a/lib/remap.js
+++ b/lib/remap.js
@@ -125,9 +125,11 @@ define([
 			end.column = end.column - 1;
 		}
 
-		resolvedSource = start.source in inlineSourceMap ? start.source : path.resolve(sourceMapDir, start.source);
-		if (!useAbsolutePaths && !(start.source in inlineSourceMap)) {
-			resolvedSource = path.relative(process.cwd(), resolvedSource);
+		if (start.source) {
+			resolvedSource = start.source in inlineSourceMap ? start.source : path.resolve(sourceMapDir, start.source);
+			if (!useAbsolutePaths && !(start.source in inlineSourceMap)) {
+				resolvedSource = path.relative(process.cwd(), resolvedSource);
+			}
 		}
 		return {
 			source: resolvedSource,
@@ -285,7 +287,7 @@ define([
 				if (sourceMap.sourcesContent) {
 					origSourceFilename = rawSourceMap.sources[0];
 
-					if(path.extname(origSourceFilename) !== ''){
+					if(!rawSourceMap.sources.length && path.extname(origSourceFilename) !== ''){
 						origFileName = rawSourceMap.file;
 						fileName = filePath.replace(path.extname(origFileName), path.extname(origSourceFilename));
 						rawSourceMap.file = fileName;
@@ -296,7 +298,7 @@ define([
 
 					sourceMap.sourcesContent.forEach(function (source, idx) {
 						inlineSourceMap[sourceMap.sources[idx]] = true;
-						getSourceCoverage(srcCoverage, sourceMap.sources[idx]).data.code = codeIsArray ? source.split('\n') : source;
+						getSourceCoverage(srcCoverage, sourceMap.sources[idx]).data.code = !codeIsArray ? source.split('\n') : source;
 						if (sourceStore) {
 							sourceStore.set(sourceMap.sources[idx], source);
 						}


### PR DESCRIPTION
When using a webpack bundle with multiple loaders, the original files often don't exist. The source code is embedded in the source map, exposed by `webpack://` URLs. This fix makes sure that the code doesn't fail if there is no filenames in `sources`, only content in `sourcesContent`, and fall back to reading the file from the filesystem.