### PR TITLE
updated supported node.js version in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 A package that provides the ability to remap [Istanbul](https://gotwarlost.github.io/istanbul/) code coverage information to its original source positions based on a JavaScript [Source Maps v3](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit#heading=h.djovrt4kdvga).
 
-`remap-istanbul` requires NodeJS 0.12 or later (which includes any version of io.js).
+`remap-istanbul` requires NodeJS 6 or later.
 
 ## How to get Help
 


### PR DESCRIPTION
Running against node.js version 4 results in this error:

```
node_modules/remap-istanbul/bin/remap-istanbul.js:19
                let buffer = '';
                ^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:373:25)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)
    at startup (node.js:139:18)
    at node.js:990:3```