### PR TITLE
fix: dont overwrite sources array

### DIFF
--- a/src/CoverageTransformer.js
+++ b/src/CoverageTransformer.js
@@ -123,7 +123,7 @@ export default class CoverageTransformer {
 		if (sourceMap.sourcesContent) {
 			origSourceFilename = rawSourceMap.sources[0];
 
-			if (origSourceFilename && path.extname(origSourceFilename) !== '') {
+			if (origSourceFilename && path.extname(origSourceFilename) !== '' && rawSourceMap.sources.length === 1) {
 				origFileName = rawSourceMap.file;
 				fileName = filePath.replace(path.extname(origFileName), path.extname(origSourceFilename));
 				rawSourceMap.file = fileName;


### PR DESCRIPTION
This PR: https://github.com/SitePen/remap-istanbul/pull/65 introduced a bug that would overwrite the sources array and lead to issues like this: https://github.com/marcules/karma-remap-istanbul/issues/31 

My workaround is to only apply this fix if there is only 1 source - however this is probably completely the wrong way to resolve this - any guidance would be greatly appreciated 😃 