### PR TITLE
fix for issue #61

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "lint": "eslint ./src/",
     "test": "tests/run.sh",
     "build": "rimraf lib && babel src --out-dir ./lib --source-maps",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "install": "npm run build"
   },
   "dependencies": {
     "amdefine": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "amdefine": "^1.0.0",
     "gulp-util": "3.0.7",
     "istanbul": "0.4.5",
+    "minimatch": "^3.0.3",
     "source-map": ">=0.5.6",
     "through2": "2.0.1"
   },

--- a/src/checkThreshold.js
+++ b/src/checkThreshold.js
@@ -1,0 +1,116 @@
+import istanbul from '../utils/node!istanbul';
+import minimatch from '../utils/node!minimatch';
+
+function mixin(destination/*, ...mixins*/) {
+    for (var i = 1; i < arguments.length; i++) {
+        var source = arguments[i];
+        for (var key in source) {
+            destination[key] = source[key];
+        }
+    }
+    return destination;
+}
+
+function overrideThresholds (key, overrides) {
+    var thresholds = {};
+
+    // First match wins
+    Object.keys(overrides).some(function (pattern) {
+        if (minimatch(normalize(key), pattern, {dot: true})) {
+            thresholds = overrides[pattern];
+            return true;
+        }
+    });
+
+    return thresholds;
+}
+
+function removeFiles (covObj, patterns) {
+    var obj = {};
+
+    Object.keys(covObj).forEach(function (key) {
+        // Do any patterns match the resolved key
+        var found = patterns.some(function (pattern) {
+            return minimatch(normalize(key), pattern, {dot: true});
+        });
+
+        // if no patterns match, keep the key
+        if (!found) {
+            obj[key] = covObj[key];
+        }
+    })
+
+    return obj;
+}
+
+export default function checkThreshold(checkOpt, collector) {
+    var defaultThresholds = {
+			global: {
+				statements: 0,
+				branches: 0,
+				lines: 0,
+				functions: 0,
+				excludes: []
+			},
+			each: {
+				statements: 0,
+				branches: 0,
+				lines: 0,
+				functions: 0,
+				excludes: [],
+				overrides: {}
+			}
+		};
+
+    var thresholds = {
+        global: mixin(defaultThresholds.global, checkOpt.global),
+        each: mixin(defaultThresholds.each, checkOpt.each)
+    };			
+
+    var rawCoverage = collector.getFinalCoverage();
+    var globalResults = istanbul.utils.summarizeCoverage(removeFiles(rawCoverage, thresholds.global.excludes));
+    var eachResults = removeFiles(rawCoverage, thresholds.each.excludes);
+
+    // Summarize per-file results and mutate original results.
+    Object.keys(eachResults).forEach(function (key) {
+        eachResults[key] = istanbul.utils.summarizeFileCoverage(eachResults[key]);
+    });
+
+    var coverageFailed = false;
+
+    function check (name, thresholds, actuals) {
+        var keys = [
+            'statements',
+            'branches',
+            'lines',
+            'functions'
+        ];
+
+        keys.forEach(function (key) {
+            var actual = actuals[key].pct;
+            var actualUncovered = actuals[key].total - actuals[key].covered;
+            var threshold = thresholds[key];
+
+            if (threshold < 0) {
+                if (threshold * -1 < actualUncovered) {
+                    coverageFailed = true;
+                    console.error('Uncovered count for ' + key + ' (' + actualUncovered + 	') exceeds ' + name + ' threshold (' + -1 * threshold + ')');
+                }
+            } else {
+                if (actual < threshold) {
+                    coverageFailed = true;
+                    console.error('Coverage for ' + key + ' (' + actual + '%) does not meet ' + name + ' threshold (' + threshold + '%)');
+                }
+            }
+        });
+    }
+
+    check('global', thresholds.global, globalResults);
+
+    Object.keys(eachResults).forEach(function (key) {
+        var keyThreshold = mixin(thresholds.each, overrideThresholds(key, thresholds.each.overrides));
+        check('per-file' + ' (' + key + ') ', keyThreshold, eachResults[key]);
+    })
+
+    return coverageFailed;
+}


### PR DESCRIPTION
Adds the ability to pass a check option from the gulp plugin to require a certain coverage threshold or fail the gulp command.

The syntax and implementation are ported from the karma-coverage test runner (https://github.com/karma-runner/karma-coverage/blob/master/docs/configuration.md#check).

usage looks like: 

```
return gulp.src('tests/coverage/coverage-final.json')
        .pipe(remapIstanbul({
            check: {
                global: {
                    statements: 50,
                    branches: 50,
                    functions: 50,
                    lines: 50,
                    excludes: [
                        'foo/bar/**/*.js'
                    ]
                },
                each: {
                    statements: 50,
                    branches: 50,
                    functions: 50,
                    lines: 50,
                    excludes: [
                        'other/directory/**/*.js'
                    ],
                    overrides: {
                        'baz/component/**/*.js': {
                            statements: 98
                        }
                    }
                }            
            },
            reports: {
                'html': 'tests/coverage/html-report',
                'cobertura': 'tests/coverage/cobertura-coverage.xml',
                'json': 'tests/coverage/coverage-remapped.json'
            }
        }));
```

No tests added or documentation updated as of yet.  