### PR TITLE
Add support for remapping filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ The argument of `options` can contain the following properties:
 |--------|----|-------|-----------|
 |basePath|String|Path found in source map|A string to use as the base path for the source locations|
 |exclude|String/RegEx/Function|`undefined`|If the filename of the source coverage file matches the String or RegEx, it will be skipped while mapping the coverage. Optionally, you can use a function that accepts the filename as the argument, and returns true if the file should be skipped.|
+|mapFileName|Function|A function that takes a single string argument that is the remapped file name and returns a string which represents the filename that should be in the mapped coverage.|
 |readFile|Function|`fs.readFileSync`|A function that will synchronously read a file|
 |readJSON|Function|`JSON.parse(fs.readFileSync)`|A function that will synchronously read a file and return a POJO based on the JSON data in the file|
 |warn|Function|`console.warn`|A function that logs warning messages|

--- a/src/CoverageTransformer.js
+++ b/src/CoverageTransformer.js
@@ -25,6 +25,8 @@ export default class CoverageTransformer {
 			}
 		}
 
+		this.mapFileName = options.mapFileName || ((fileName) => fileName);
+
 		this.useAbsolutePaths = !!options.useAbsolutePaths;
 
 		this.readJSON = options.readJSON
@@ -239,12 +241,15 @@ export default class CoverageTransformer {
 
 		const srcCoverage = this.sparceCoverageCollector.getFinalCoverage();
 
-		collector.add(Object.keys(srcCoverage)
+		Object.keys(srcCoverage)
 			.filter((filePath) => !this.exclude(filePath))
-			.reduce((obj, name) => {
-				obj[name] = srcCoverage[name];
-				return obj;
-			}, {}));
+			.forEach((filename) => {
+				const coverage = Object.assign({}, srcCoverage[filename]);
+				coverage.path = this.mapFileName(filename);
+				collector.add({
+					[coverage.path]: coverage
+				});
+			});
 
 		/* refreshes the line counts for reports */
 		collector.getFinalCoverage();

--- a/src/remap.js
+++ b/src/remap.js
@@ -7,18 +7,21 @@ import CoverageTransformer from './CoverageTransformer';
  * @param  {Array|Object} coverage The coverage (or array of coverages) that need to be
  *                                 remapped
  * @param  {Object} options A configuration object:
- *                              basePath? - a string containing to utilise as the base path
- *                                          for determining the location of the source file
- *                              exclude?  - a string or Regular Expression that filters out
- *                                          any coverage where the file path matches
- *                              readFile? - a function that can read a file
- *                                          syncronously
- *                              readJSON? - a function that can read and parse a
- *                                          JSON file syncronously
- *                              sources?  - a Istanbul store where inline sources will be
- *                                          added
- *                              warn?     - a function that logs warnings
- * @return {istanbul/lib/_collector}         The remapped collector
+ *                              basePath?    - a string containing to utilise as the base path
+ *                                             for determining the location of the source file
+ *                              exclude?     - a string or Regular Expression that filters out
+ *                                             any coverage where the file path matches
+ *                              mapFileName? - a function that takes the remapped file name and
+ *                                             and returns a string that should be the name in
+ *                                             the final coverage
+ *                              readFile?    - a function that can read a file
+ *                                             syncronously
+ *                              readJSON?    - a function that can read and parse a
+ *                                             JSON file syncronously
+ *                              sources?     - a Istanbul store where inline sources will be
+ *                                             added
+ *                              warn?        - a function that logs warnings
+ * @return {istanbul/lib/_collector}           The remapped collector
  */
 export default function remap(coverage, options = {}) {
 	const smc = new CoverageTransformer(options);

--- a/tests/unit/lib/remap.js
+++ b/tests/unit/lib/remap.js
@@ -237,6 +237,23 @@ define([
 
 		},
 
+		'mapFileName': function () {
+			var warnStack = [];
+
+			var coverage = remap(loadCoverage('tests/unit/support/coverage.json'), {
+				warn: function () {
+					warnStack.push(arguments);
+				},
+				mapFileName: function (filename) {
+					return 'bar/' + filename;
+				}
+			});
+
+			assert.strictEqual(warnStack.length, 0);
+			var coverageData = JSON.parse(coverage.store.map['bar/tests/unit/support/basic.ts']);
+			assert.strictEqual(coverageData.path, 'bar/tests/unit/support/basic.ts');
+		},
+
 		'useAbsolutePaths': function () {
 			var coverage = remap(loadCoverage('tests/unit/support/coverage.json'), {
 				useAbsolutePaths: true


### PR DESCRIPTION
This PR provides the ability to pass a option named `mapFileName` to the `remap()` function, which is a function which takes the remapped filename as a string and returns a string which represents the final filename which should be added to the remapped coverage.

This makes it possible to *unmangle* filenames that are potentially mangled by bundlers and would support "rebasing" of files in the remapped coverage.

Fixes #143 