### PR TITLE
Also remap sources when remapping filenames

### DIFF
--- a/src/CoverageTransformer.js
+++ b/src/CoverageTransformer.js
@@ -246,6 +246,10 @@ export default class CoverageTransformer {
 			.forEach((filename) => {
 				const coverage = Object.assign({}, srcCoverage[filename]);
 				coverage.path = this.mapFileName(filename);
+				if (this.sourceStore && coverage.path !== filename) {
+					const source = this.sourceStore.get(filename);
+					this.sourceStore.set(coverage.path, source);
+				}
 				collector.add({
 					[coverage.path]: coverage
 				});

--- a/tests/unit/lib/remap.js
+++ b/tests/unit/lib/remap.js
@@ -254,6 +254,18 @@ define([
 			assert.strictEqual(coverageData.path, 'bar/tests/unit/support/basic.ts');
 		},
 
+		'mapFileName with sources': function () {
+			var store = new MemoryStore();
+			remap(loadCoverage('tests/unit/support/coverage-inlinesource.json'), {
+				sources: store,
+
+				mapFileName: function (filename) {
+					return 'bar/' + filename;
+				}
+			});
+			assert(store.map['bar/tests/unit/support/inlinesource.ts'], 'Source should be available on renamed file');
+		},
+
 		'useAbsolutePaths': function () {
 			var coverage = remap(loadCoverage('tests/unit/support/coverage.json'), {
 				useAbsolutePaths: true


### PR DESCRIPTION
This fixes and issue where if a store of sources was passed to `remap()` and the filenames were remapped, the corresponding change was not made in the source store.