### PR TITLE
Add warnMissingSourceMaps parameter

### DIFF
--- a/src/CoverageTransformer.js
+++ b/src/CoverageTransformer.js
@@ -13,6 +13,7 @@ export default class CoverageTransformer {
 	constructor(options) {
 		this.basePath = options.basePath;
 		this.warn = options.warn || console.warn;
+		this.warnMissingSourceMaps = options.warnMissingSourceMaps || true;
 
 		this.exclude = () => false;
 		if (options.exclude) {
@@ -97,7 +98,9 @@ export default class CoverageTransformer {
 
 		if (!rawSourceMap) {
 			/* We couldn't find a source map, so will copy coverage after warning. */
-			this.warn(new Error(`Could not find source map for: "${filePath}"`));
+			if (this.warnMissingSourceMap) {
+				this.warn(new Error(`Could not find source map for: "${filePath}"`));
+			}
 			try {
 				fileCoverage.code = String(fs.readFileSync(filePath)).split('\n');
 			} catch (error) {

--- a/src/CoverageTransformer.js
+++ b/src/CoverageTransformer.js
@@ -98,7 +98,7 @@ export default class CoverageTransformer {
 
 		if (!rawSourceMap) {
 			/* We couldn't find a source map, so will copy coverage after warning. */
-			if (this.warnMissingSourceMap) {
+			if (this.warnMissingSourceMaps) {
 				this.warn(new Error(`Could not find source map for: "${filePath}"`));
 			}
 			try {

--- a/src/gruntRemapIstanbul.js
+++ b/src/gruntRemapIstanbul.js
@@ -29,6 +29,7 @@ export default function gruntPlugin(grunt) {
 				readFile: grunt.readFile,
 				readJSON: grunt.readJSON,
 				warn,
+				warnMissingSourceMaps: options.warnMissingSourceMaps,
 				sources,
 				basePath: file.basePath,
 				useAbsolutePaths: options.useAbsolutePaths,


### PR DESCRIPTION
Previously, there was no way to suppress these errors when a source map could not be found:

```
>> Error: Could not find source map for: "app/src/blah.js"
```

For projects that are in the process of migrating to TypeScript, not all files will have corresponding source maps.

This adds a `warnMissingSourceMaps` parameter (defaults to `true` to keep existing behavior) which can be used to suppress these errors.