### PR TITLE
Checking if 'origFileName' is defined before using it to build a file path

### DIFF
--- a/src/CoverageTransformer.js
+++ b/src/CoverageTransformer.js
@@ -210,7 +210,7 @@ export default class CoverageTransformer {
 		// todo: refactor exposing implementation details
 		const srcCoverage = this.sparceCoverageCollector.getFinalCoverage();
 
-		if (sourceMap.sourcesContent && this.basePath) {
+		if (sourceMap.sourcesContent && this.basePath && origFileName) {
 			// Convert path to use base path option
 			const getPath = filePath => {
 				const absolutePath = path.resolve(this.basePath, filePath);


### PR DESCRIPTION
When a basePath is specified, if the origFileName is undefined, the program errors out when executing the replace() method.