### PR TITLE
Allow null file name

### DIFF
--- a/bin/remap-istanbul.js
+++ b/bin/remap-istanbul.js
@@ -140,6 +140,9 @@ function main(argv) {
 		}
 		const reportOptions = {};
 		if (output) {
+			if (output === 'null') {
+				output = null;
+			}
 			return writeReport(collector, reportType || 'json', reportOptions, output, sources);
 		}
 		if (reportType && (reportType === 'lcovonly' || reportType === 'text-lcov')) {

--- a/tests/unit/bin/remap-istanbul.js
+++ b/tests/unit/bin/remap-istanbul.js
@@ -86,10 +86,18 @@ define([
 				'--type', 'text-lcov'
 			]);
 		},
-		'stdout': function () {
-			remapIstanbul([
-				'--input', 'tests/unit/support/coverage-inlinesource.json'
-			]);
+		'stdout': {
+			'default': function () {
+				remapIstanbul([
+					'--input', 'tests/unit/support/coverage-inlinesource.json'
+				]);
+			},
+			'text-summary': function () {
+				remapIstanbul([
+					'--input', 'tests/unit/support/coverage-inlinesource.json',
+					'--output', 'null'
+				]);
+			}
 		},
 		'bad argument': function () {
 			assert.throws(function () {


### PR DESCRIPTION
This change allows specifying '-o null' to specify that the filename should
be set to null. Doing so allows the reports such as 'text-summary' to be
printed to console instead of a file.