### PR TITLE
dirname repeating bug fix

### DIFF
--- a/src/CoverageTransformer.js
+++ b/src/CoverageTransformer.js
@@ -89,7 +89,7 @@ export default class CoverageTransformer {
 				if (match[1]) {
 					rawSourceMap = JSON.parse((new Buffer(match[2], 'base64').toString('utf8')));
 				} else {
-					const sourceMapPath = path.join(sourceMapDir, match[2]);
+					const sourceMapPath = path.join(sourceMapDir, path.basename(match[2]));
 					rawSourceMap = this.readJSON(sourceMapPath);
 					sourceMapDir = path.dirname(sourceMapPath);
 				}


### PR DESCRIPTION
In previous version, sourceMapPath becomes like `/home/foo/bar/home/foo/bar/xxx.map.js`, but should be like `/home/foo/bar/xxx.map.js`, I think.