### PR TITLE
Lock down version of source-map ^0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "istanbul": "0.4.5",
     "minimatch": "^3.0.3",
     "plugin-error": "^0.1.2",
-    "source-map": ">=0.5.6",
+    "source-map": "^0.6.1",
     "through2": "2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
prevent pulling in source-map 0.7.0 by pinning to 0.6.X