### PR TITLE
Fix warnMissingSourceMaps always set to true

### DIFF
--- a/src/CoverageTransformer.js
+++ b/src/CoverageTransformer.js
@@ -13,7 +13,8 @@ export default class CoverageTransformer {
 	constructor(options) {
 		this.basePath = options.basePath;
 		this.warn = options.warn || console.warn;
-		this.warnMissingSourceMaps = options.warnMissingSourceMaps || true;
+		this.warnMissingSourceMaps =
+			(typeof options.warnMissingSourceMaps !== 'undefined') ? options.warnMissingSourceMaps : true;
 
 		this.exclude = () => false;
 		if (options.exclude) {


### PR DESCRIPTION
This is a fix for #150. See my review there.

Just fixing the logic for setting the instance `warnMissingSourceMaps` property - we want to allow falsy values from `options`. 