### PR TITLE
fix: path replace fail when dirname has same ext

### DIFF
--- a/src/CoverageTransformer.js
+++ b/src/CoverageTransformer.js
@@ -145,7 +145,7 @@ export default class CoverageTransformer {
 
 			if (origSourceFilename && path.extname(origSourceFilename) !== '' && rawSourceMap.sources.length === 1) {
 				origFileName = rawSourceMap.file || rawSourceMap.sources[0];
-				fileName = filePath.replace(path.extname(origFileName), path.extname(origSourceFilename));
+				fileName = filePath.replace(new RegExp(path.extname(origFileName) + '$'), path.extname(origSourceFilename));
 				rawSourceMap.file = fileName;
 				rawSourceMap.sources = [fileName];
 				rawSourceMap.sourceRoot = '';


### PR DESCRIPTION
There are some projects which have an `extname` on its project name. According the results of the query from npmjs.com... - https://www.npmjs.com/search?q=.js

* https://www.npmjs.com/package/popper.js
* https://www.npmjs.com/package/big.js
* https://www.npmjs.com/package/hash.js
* https://www.npmjs.com/package/reveal.js

Let's say that we are making a project named abc.js on TypeScript; We are building something on the directory like below,

```bash
/Users/heycalmdown/development/abc.js$ npm run lcov-remap
```

The `coverage/lcov.info` will start with 

```
TN:
SF:/Users/heycalmdown/development/abc.js/dist/index.js
```

And the remap file starts with

```
TN:
SF:/Users/heycalmdown/development/abc.ts/dist/index.js
```

Expected result is

```
TN:
SF:/Users/heycalmdown/development/abc.js/dist/index.ts
```
